### PR TITLE
ES6 class fixes + readme updated :cookie:

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ You can get your HackerRank API Key by visiting [HackerRank API](https://www.hac
 
 ### Methods available
 
-* `_runURL` : Get Run URL
-* `_langURL` : Get Language URL
-* `_apiKey` : Get API Key
-* `getLanguages( callback )` : Gets and returns languages response from HackerRank
-* `run ( config, callback )` : Posts and returns response to callback from HackerRank after running the code on testcases provided
+* `runURL` : Get Run URL
+* `langURL` : Get Language URL
+* `apiKey` : Get API Key
+* `getLanguages( callback )` : Returns languages as a response from HackerRank
+* `run ( config, callback )` : Returns response as a callback from HackerRank after running the code on testcases provided
 
 ### Config
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ var gutil = require('gulp-util');
 var babel = require('gulp-babel');
 
 
-gulp.task('browser', function() {
+gulp.task('browser', _ => {
   browserify({ debug: true })
     .transform(babelify)
     .require("./Example/test.js", { entry: true })
@@ -23,7 +23,7 @@ gulp.task('browser', function() {
     .pipe(gulp.dest('./Example/source'));
 });
 
-gulp.task('es6', function(){
+gulp.task('es6',_ => {
   gulp.src('src/*.js')
     .pipe(babel({
       presets: ['es2015']
@@ -31,7 +31,7 @@ gulp.task('es6', function(){
     .pipe(gulp.dest('./dist'))
 });
 
-gulp.task('watch',function() {
+gulp.task('watch',_ => {
   gulp.watch(['./src/*.js'],['browser', 'es6'])
 });
  

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class HackerRank {
   }
 
   getLanguages(callback) {
-    request({url: this._langURL}, (error, response) => {
+    request({url: this.langURL}, (error, response) => {
       if (!error && response.statusCode === 200) {
         callback(null, response);
       } else {
@@ -50,7 +50,7 @@ class HackerRank {
   }
 
   postRun(queryData, callback) {
-    request.post({ url : this._runURL, form : queryData}, (error, response) => {
+    request.post({ url : this.runURL, form : queryData}, (error, response) => {
       if(error){
         callback(error, null);
       }
@@ -61,7 +61,7 @@ class HackerRank {
   }
 
   run(config, callback) {
-    let queryData = this.getQuery(config, this._apiKey);
+    let queryData = this.getQuery(config, this.apiKey);
     return this.postRun(queryData, callback);
   }
 }


### PR DESCRIPTION
Hi @ManrajGrover ,

I saw in your ES6 classes code in `src/index.js` you have defined some `getters` to get the properties of class HackerRank Like below :- 

``` js
get runURL() {
    return this._runURL;
  }
```

But when your were trying to acces runURL you were still using old `._runURL` method and same was reflected in your readme.

But essentially what happens when you have some `getters/setters` in your ES6 classes they work as a proxy. What i meant by this is , if you now try to access `this.runURL` it will go to get function of that and return whatever you were trying to return this way, your code will be much more abstracted from your users and you are not exposing some inner workings of your code.

This way you are making your code adhere to some good practices.
Cheers,
:coffee: 
